### PR TITLE
Fixing the typo for the link to Lightstep app

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Note that the all-in-one docker image presents the Zipkin UI at [localhost:9411]
 
 #### LightStep
 
-If you have access to [LightStep](https://app.lightstep.com]), you will need your access token. Add the following to `microdonuts/tracer_config.properties`:
+If you have access to [LightStep](https://app.lightstep.com), you will need your access token. Add the following to `microdonuts/tracer_config.properties`:
 
 ```properties
 tracer=lightstep


### PR DESCRIPTION
Fixing the typo for the link to Lightstep app. Small typo fix where the markdown link was created incorrectly.