### PR TITLE
updated host and port

### DIFF
--- a/microdonuts/tracer_config.properties
+++ b/microdonuts/tracer_config.properties
@@ -12,6 +12,6 @@ zipkin.reporter_host=localhost
 zipkin.reporter_port=9411
 
 // LightStep config
-lightstep.collector_host=collector.lightstep.com
-lightstep.collector_port=80
+lightstep.collector_host=collector-grpc.lightstep.com
+lightstep.collector_port=443
 lightstep.access_token={your_token}


### PR DESCRIPTION
due to the default to grpc, and the changes in the last 6 months to the lightstep public collectors, I've changed the default values here to reflect the closest "clone and play" values a user would need to use this app with LightStep.