### PR TITLE
Fix broken link to lightstep.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Note that the all-in-one docker image presents the Zipkin UI at [localhost:9411]
 
 #### LightStep
 
-If you have access to [LightStep](https://app.lightstep.com]), you will need your access token. Add the following to `microdonuts/tracer_config.properties`:
+If you have access to [LightStep](https://go.lightstep.com/tracing.html), you will need your access token. Add the following to `microdonuts/tracer_config.properties`:
 
 ```properties
 tracer=lightstep


### PR DESCRIPTION
* Original link had an extra "]" character which made it invalid
* Changed link to be directly to the sign-up for convenience (presumably most people coming through the README will need to sign-up rather than login)